### PR TITLE
feat: Direct card interaction for touch/click controls

### DIFF
--- a/frontend/src/components/CardDisplay.tsx
+++ b/frontend/src/components/CardDisplay.tsx
@@ -75,8 +75,9 @@ export function CardDisplay({
     effectiveBorderColor = '#FFD700'; // Gold color for selection
     boxShadow = '0 0 12px rgba(255, 215, 0, 0.9), 0 0 24px rgba(255, 215, 0, 0.5)';
   } else if (isHighlighted) {
-    effectiveBorderColor = 'var(--ui-highlight)';
-    boxShadow = '0 0 12px rgba(74, 123, 255, 0.4)';
+    // Subtle green glow for actionable cards (can tussle or use ability)
+    effectiveBorderColor = '#22c55e'; // Green border
+    boxShadow = '0 0 8px rgba(34, 197, 94, 0.5)';
   }
 
   return (

--- a/frontend/src/components/GameMessages.tsx
+++ b/frontend/src/components/GameMessages.tsx
@@ -1,0 +1,139 @@
+/**
+ * GameMessages Component
+ * 
+ * Displays game messages/play-by-play with collapsible functionality.
+ * Supports both desktop and compact (tablet) modes.
+ */
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface GameMessagesProps {
+  messages: string[];
+  isAIThinking?: boolean;
+  compact?: boolean;  // Compact mode for tablet
+}
+
+export function GameMessages({ 
+  messages, 
+  isAIThinking = false, 
+  compact = false 
+}: GameMessagesProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  // In compact mode, show fewer messages by default
+  const displayMessages = compact ? messages.slice(-5) : messages;
+  const messageCount = messages.length;
+
+  return (
+    <div className="bg-gray-800 rounded border border-gray-700 overflow-hidden">
+      {/* Header - Always visible, clickable to toggle */}
+      <button
+        onClick={() => setIsCollapsed(!isCollapsed)}
+        className={`
+          w-full flex items-center justify-between
+          ${compact ? 'px-2 py-1.5' : 'px-3 py-2'}
+          bg-gray-900 hover:bg-gray-800 transition-colors
+          ${!isCollapsed ? 'border-b border-gray-700' : ''}
+        `}
+      >
+        <div className="flex items-center gap-2">
+          <span className={`text-gray-400 font-medium ${compact ? 'text-xs' : 'text-sm'}`}>
+            Game Log
+          </span>
+          {messageCount > 0 && (
+            <span className={`
+              px-1.5 py-0.5 rounded-full bg-blue-900 text-blue-300
+              ${compact ? 'text-[10px]' : 'text-xs'}
+            `}>
+              {messageCount}
+            </span>
+          )}
+        </div>
+        <svg
+          className={`text-gray-400 flex-shrink-0 transition-transform duration-200 ${isCollapsed ? '' : 'rotate-180'} ${compact ? 'w-3 h-3' : 'w-4 h-4'}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          style={{ width: compact ? '12px' : '16px', height: compact ? '12px' : '16px' }}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+        </svg>
+      </button>
+
+      {/* Collapsible Content */}
+      <AnimatePresence initial={false}>
+        {!isCollapsed && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div
+              className={compact ? 'p-2' : 'p-3'}
+              style={{ 
+                maxHeight: compact ? '150px' : '350px', 
+                overflowY: 'auto' 
+              }}
+            >
+              {displayMessages.length === 0 && !isAIThinking ? (
+                <div className={`text-gray-500 italic ${compact ? 'text-xs' : 'text-sm'}`}>
+                  No messages yet
+                </div>
+              ) : (
+                <div className={compact ? 'space-y-1' : 'space-y-2'}>
+                  {displayMessages.map((msg, idx) => (
+                    <div 
+                      key={idx} 
+                      className={`
+                        bg-blue-900 rounded
+                        ${compact ? 'p-1 text-xs' : 'p-2 text-sm'}
+                      `}
+                    >
+                      {msg}
+                    </div>
+                  ))}
+                  {isAIThinking && (
+                    <div 
+                      className={`
+                        bg-purple-900 rounded inline-flex items-center
+                        ${compact ? 'p-1 text-xs gap-1.5' : 'p-2 text-sm gap-2'}
+                      `}
+                    >
+                      <svg 
+                        style={{ 
+                          width: compact ? '12px' : '14px', 
+                          height: compact ? '12px' : '14px', 
+                          flexShrink: 0 
+                        }}
+                        className="animate-spin text-purple-300" 
+                        xmlns="http://www.w3.org/2000/svg" 
+                        fill="none" 
+                        viewBox="0 0 24 24"
+                      >
+                        <circle 
+                          className="opacity-25" 
+                          cx="12" cy="12" r="10" 
+                          stroke="currentColor" 
+                          strokeWidth="4"
+                        />
+                        <path 
+                          className="opacity-75" 
+                          fill="currentColor" 
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      <span>{compact ? 'Opponent thinking...' : 'Opponent is thinking...'}</span>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/components/InPlayZone.tsx
+++ b/frontend/src/components/InPlayZone.tsx
@@ -1,6 +1,9 @@
 /**
  * InPlayZone Component
  * Displays cards that are in play for a player
+ * 
+ * Supports direct card interaction for tussles and activated abilities.
+ * Cards that have available actions show a subtle glow when hovered.
  */
 
 import { CardDisplay } from './CardDisplay';
@@ -12,6 +15,8 @@ interface InPlayZoneProps {
   isHuman?: boolean;
   selectedCard?: string;  // Now expects card ID instead of card name
   onCardClick?: (cardId: string) => void;
+  actionableCardIds?: string[];  // IDs of cards that can perform actions (tussle/ability)
+  isPlayerTurn?: boolean;  // Whether it's the player's turn
   cardSize?: 'small' | 'medium';  // Responsive card size
   enableLayoutAnimation?: boolean;  // Enable smooth zone transitions
 }
@@ -21,6 +26,8 @@ export function InPlayZone({
   isHuman = false, 
   selectedCard, 
   onCardClick, 
+  actionableCardIds = [],
+  isPlayerTurn = false,
   cardSize = 'medium',
   enableLayoutAnimation = false,
 }: InPlayZoneProps) {
@@ -44,17 +51,26 @@ export function InPlayZone({
           </div>
         ) : (
           <div className="flex flex-wrap gap-2">
-            {cardList.map((card) => (
-              <CardDisplay
-                key={card.id}
-                card={card}
-                size={cardSize}
-                isSelected={selectedCard === card.id}
-                isClickable={isHuman && !!onCardClick}
-                onClick={isHuman && onCardClick ? () => onCardClick(card.id) : undefined}
-                enableLayoutAnimation={enableLayoutAnimation}
-              />
-            ))}
+            {cardList.map((card) => {
+              // Card is actionable if it's in the actionable list (can tussle or use ability)
+              const isActionable = isPlayerTurn && actionableCardIds.includes(card.id);
+              // Card is clickable if it's the human's zone, has a click handler, AND has an action
+              // Non-actionable cards are still visible but not clickable
+              const isClickable = isHuman && !!onCardClick && isActionable;
+              
+              return (
+                <CardDisplay
+                  key={card.id}
+                  card={card}
+                  size={cardSize}
+                  isSelected={selectedCard === card.id}
+                  isClickable={isClickable}
+                  isHighlighted={isActionable}
+                  onClick={isClickable ? () => onCardClick(card.id) : undefined}
+                  enableLayoutAnimation={enableLayoutAnimation}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/frontend/src/components/TargetSelectionModal.tsx
+++ b/frontend/src/components/TargetSelectionModal.tsx
@@ -124,11 +124,15 @@ export function TargetSelectionModal({
         {/* Header */}
         <div className="p-4 border-b-4 border-game-accent bg-gray-800 flex-shrink-0">
           <h2 className="text-2xl font-bold mb-1 text-game-highlight">
-            Playing {action.card_name}
+            {action.action_type === 'tussle' 
+              ? `Tussle with ${action.card_name}` 
+              : `Playing ${action.card_name}`}
           </h2>
-          <p className="text-base text-gray-300 mb-3">
-            Cost: {action.cost_cc} CC
-          </p>
+          {action.action_type !== 'tussle' && action.cost_cc !== undefined && (
+            <p className="text-base text-gray-300 mb-3">
+              Cost: {action.cost_cc} CC
+            </p>
+          )}
           <p className="text-base text-gray-100 mb-3">
             {action.description}
           </p>
@@ -145,12 +149,14 @@ export function TargetSelectionModal({
               className={`
                 px-8 py-3 rounded-lg font-bold transition-all text-white
                 ${canConfirm()
-                  ? 'bg-game-highlight hover:bg-red-600 cursor-pointer'
+                  ? action.action_type === 'tussle' 
+                    ? 'bg-red-600 hover:bg-red-700 cursor-pointer'
+                    : 'bg-game-highlight hover:bg-red-600 cursor-pointer'
                   : 'bg-gray-600 cursor-not-allowed opacity-50'
                 }
               `}
             >
-              Confirm
+              {action.action_type === 'tussle' ? 'Attack!' : 'Confirm'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Implements Issue #121 - Direct card interaction as an alternative to the action panel.

## Changes

### Direct Card Interaction
- **Hand Zone**: Clicking a playable card immediately plays it (opens target selection modal if the card requires targets like Copy, Wake, Sun)
- **InPlay Zone - Tussle**: Clicking your own card that can tussle opens a target selection modal to choose the defender
- **InPlay Zone - Activated Abilities**: Clicking a card with an activated ability (like Archer) triggers the ability flow

### Visual Feedback
- Cards that can perform actions (tussle or activated ability) show a subtle **green glow** border
- Non-actionable cards in play are displayed normally (not dimmed)
- Maintains existing gold glow for selected cards

### Target Selection Modal Improvements
- Shows "Tussle with {card_name}" header for tussle actions
- "Attack!" button text for tussle confirmation
- Hides CC cost display for tussle actions (they have no cost)

### Collapsible Game Log
- New `GameMessages` component with collapsible functionality
- Click header to expand/collapse
- Shows message count badge
- Smooth animation
- Works in both desktop and compact (tablet) modes

## What's Preserved
- ✅ Action panel remains visible for accessibility and to guide new players
- ✅ Keyboard shortcuts (1-9, 0) still work
- ✅ End Turn button kept separate

## Testing
- Tested locally on desktop
- Ready for more extensive testing in production

Closes #121