### PR TITLE
fix: Default AI player name to 'Gemiknight' in single-player mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -208,7 +208,9 @@ function GameApp() {
   }
 
   if (gamePhase === 'deck-selection-p2') {
-    return <DeckSelection onDeckSelected={handlePlayer2DeckSelected} hiddenMode={hiddenCardsMode} />;
+    // For AI games (single-player), use "Gemiknight" as the AI's name
+    const aiDefaultName = gameMode === 'single-player' ? 'Gemiknight' : undefined;
+    return <DeckSelection onDeckSelected={handlePlayer2DeckSelected} hiddenMode={hiddenCardsMode} defaultPlayerName={aiDefaultName} />;
   }
 
   if (gamePhase === 'playing' && gameId) {

--- a/frontend/src/components/DeckSelection.tsx
+++ b/frontend/src/components/DeckSelection.tsx
@@ -13,9 +13,10 @@ import type { CardDataResponse } from '../types/api';
 interface DeckSelectionProps {
   onDeckSelected: (deck: string[], playerName: string) => void;
   hiddenMode?: boolean;  // When true, cards are face-down and only random selection works
+  defaultPlayerName?: string;  // Override the default player name (for AI player)
 }
 
-export function DeckSelection({ onDeckSelected, hiddenMode = false }: DeckSelectionProps) {
+export function DeckSelection({ onDeckSelected, hiddenMode = false, defaultPlayerName }: DeckSelectionProps) {
   const { user } = useAuth();
   const [selectedCards, setSelectedCards] = useState<string[]>([]);
   const [numToys, setNumToys] = useState(4); // Default: 4 Toys
@@ -24,8 +25,8 @@ export function DeckSelection({ onDeckSelected, hiddenMode = false }: DeckSelect
   const [cards, setCards] = useState<CardDataResponse[]>([]);
   const [isLoadingCards, setIsLoadingCards] = useState(true);
 
-  // Get display name from authenticated user
-  const playerName = user?.display_name || 'Player';
+  // Use provided default name, or get display name from authenticated user
+  const playerName = defaultPlayerName || user?.display_name || 'Player';
 
   // Load cards from backend on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes Issue #136 - AI player was incorrectly using the logged-in user's display name instead of having its own name.

## Problem

After PR #134 (OAuth integration), both players in single-player (vs AI) mode were showing the same name - the logged-in user's display name. This made the game confusing as you couldn't tell which player was which.

## Solution

- Added `defaultPlayerName` prop to `DeckSelection` component
- When in single-player mode, the AI player's deck selection screen now defaults to "Gemiknight" as the player name
- Human player continues to use their authenticated display name

## Changes

- `DeckSelection.tsx`: Added optional `defaultPlayerName` prop that overrides the auth user's name when provided
- `App.tsx`: Pass "Gemiknight" as the default name for AI player in single-player mode

Fixes #136