### PR TITLE
feat: Add AI decision logging, game playback, and player stats

### DIFF
--- a/backend/alembic/versions/004_create_stats_tables.py
+++ b/backend/alembic/versions/004_create_stats_tables.py
@@ -1,0 +1,177 @@
+"""create stats and logging tables
+
+Revision ID: 004
+Revises: 003
+Create Date: 2025-12-01 12:00:00.000000
+
+This migration creates tables for:
+- ai_decision_logs: Stores AI prompts/responses (1 hour retention)
+- game_playback: Stores completed game summaries (24 hour retention)
+- player_stats: Stores aggregate player statistics (permanent)
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '004'
+down_revision: Union[str, None] = '003'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create AI decision logs, game playback, and player stats tables."""
+    
+    # ========================================
+    # AI Decision Logs (1 hour retention)
+    # ========================================
+    op.create_table(
+        'ai_decision_logs',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('game_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('turn_number', sa.Integer(), nullable=False),
+        sa.Column('player_id', sa.String(length=255), nullable=True),
+        sa.Column('model_name', sa.String(length=100), nullable=False),
+        sa.Column('prompts_version', sa.String(length=20), nullable=False),
+        sa.Column('prompt', sa.Text(), nullable=False),
+        sa.Column('response', sa.Text(), nullable=False),
+        sa.Column('action_number', sa.Integer(), nullable=True),
+        sa.Column('reasoning', sa.Text(), nullable=True),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_ai_decision_logs'))
+    )
+    
+    # Indexes for ai_decision_logs
+    op.create_index(
+        op.f('idx_ai_decision_logs_game_id'),
+        'ai_decision_logs',
+        ['game_id'],
+        unique=False
+    )
+    op.create_index(
+        op.f('idx_ai_decision_logs_created_at'),
+        'ai_decision_logs',
+        ['created_at'],
+        unique=False
+    )
+    
+    # ========================================
+    # Game Playback (24 hour retention)
+    # ========================================
+    op.create_table(
+        'game_playback',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('game_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('player1_id', sa.String(length=255), nullable=False),
+        sa.Column('player1_name', sa.String(length=255), nullable=False),
+        sa.Column('player2_id', sa.String(length=255), nullable=False),
+        sa.Column('player2_name', sa.String(length=255), nullable=False),
+        sa.Column('winner_id', sa.String(length=255), nullable=True),
+        sa.Column('starting_deck_p1', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('starting_deck_p2', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('first_player_id', sa.String(length=255), nullable=False),
+        sa.Column('play_by_play', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('turn_count', sa.Integer(), nullable=False),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False
+        ),
+        sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_game_playback'))
+    )
+    
+    # Indexes for game_playback
+    op.create_index(
+        op.f('idx_game_playback_game_id'),
+        'game_playback',
+        ['game_id'],
+        unique=True
+    )
+    op.create_index(
+        op.f('idx_game_playback_created_at'),
+        'game_playback',
+        ['created_at'],
+        unique=False
+    )
+    op.create_index(
+        op.f('idx_game_playback_winner_id'),
+        'game_playback',
+        ['winner_id'],
+        unique=False
+    )
+    
+    # ========================================
+    # Player Stats (permanent)
+    # ========================================
+    op.create_table(
+        'player_stats',
+        sa.Column('player_id', sa.String(length=255), nullable=False),
+        sa.Column('display_name', sa.String(length=255), nullable=False),
+        sa.Column('games_played', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('games_won', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('total_tussles', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('tussles_won', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column(
+            'card_stats',
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default='{}'
+        ),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False
+        ),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False
+        ),
+        sa.PrimaryKeyConstraint('player_id', name=op.f('pk_player_stats'))
+    )
+    
+    # Indexes for player_stats (leaderboards)
+    op.create_index(
+        op.f('idx_player_stats_games_won'),
+        'player_stats',
+        ['games_won'],
+        unique=False
+    )
+    op.create_index(
+        op.f('idx_player_stats_games_played'),
+        'player_stats',
+        ['games_played'],
+        unique=False
+    )
+
+
+def downgrade() -> None:
+    """Drop stats and logging tables."""
+    # Drop player_stats
+    op.drop_index(op.f('idx_player_stats_games_played'), table_name='player_stats')
+    op.drop_index(op.f('idx_player_stats_games_won'), table_name='player_stats')
+    op.drop_table('player_stats')
+    
+    # Drop game_playback
+    op.drop_index(op.f('idx_game_playback_winner_id'), table_name='game_playback')
+    op.drop_index(op.f('idx_game_playback_created_at'), table_name='game_playback')
+    op.drop_index(op.f('idx_game_playback_game_id'), table_name='game_playback')
+    op.drop_table('game_playback')
+    
+    # Drop ai_decision_logs
+    op.drop_index(op.f('idx_ai_decision_logs_created_at'), table_name='ai_decision_logs')
+    op.drop_index(op.f('idx_ai_decision_logs_game_id'), table_name='ai_decision_logs')
+    op.drop_table('ai_decision_logs')

--- a/backend/src/api/db_models.py
+++ b/backend/src/api/db_models.py
@@ -6,7 +6,7 @@ Defines the database schema using SQLAlchemy declarative models.
 
 from datetime import datetime
 from sqlalchemy import (
-    Column, String, Integer, DateTime, Text, CheckConstraint, Index
+    Column, String, Integer, DateTime, Text, CheckConstraint, Index, ForeignKey
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.ext.declarative import declarative_base
@@ -226,3 +226,149 @@ class GameStatsModel(Base):
     
     def __repr__(self):
         return f"<GameStats(id={self.id}, game_id={self.game_id}, winner={self.winner_id})>"
+
+
+class AIDecisionLogModel(Base):
+    """
+    Database model for AI decision logs.
+    
+    Stores Gemini prompts and responses for debugging AI behavior.
+    Retention: 1 hour (cleaned up by scheduled task).
+    """
+    __tablename__ = "ai_decision_logs"
+    
+    # Primary key
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    
+    # Game context
+    game_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    turn_number = Column(Integer, nullable=False)
+    player_id = Column(String(255), nullable=True)  # AI player ID in game
+    
+    # AI model info for tracking improvements
+    model_name = Column(String(100), nullable=False)  # e.g., "gemini-2.0-flash"
+    prompts_version = Column(String(20), nullable=False)  # e.g., "1.0"
+    
+    # Request/response data
+    prompt = Column(Text, nullable=False)
+    response = Column(Text, nullable=False)
+    
+    # Parsed action (for quick analysis)
+    action_number = Column(Integer, nullable=True)
+    reasoning = Column(Text, nullable=True)
+    
+    # Timestamp for retention cleanup
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        index=True  # Index for cleanup queries
+    )
+    
+    def __repr__(self):
+        return f"<AIDecisionLog(id={self.id}, game_id={self.game_id}, turn={self.turn_number})>"
+
+
+class GamePlaybackModel(Base):
+    """
+    Database model for game playback data.
+    
+    Stores completed game summaries with starting decks and play-by-play.
+    Retention: 24 hours (cleaned up by scheduled task).
+    """
+    __tablename__ = "game_playback"
+    
+    # Primary key
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    
+    # Game reference
+    game_id = Column(UUID(as_uuid=True), nullable=False, unique=True, index=True)
+    
+    # Player info
+    player1_id = Column(String(255), nullable=False)
+    player1_name = Column(String(255), nullable=False)
+    player2_id = Column(String(255), nullable=False)
+    player2_name = Column(String(255), nullable=False)
+    winner_id = Column(String(255), nullable=True, index=True)
+    
+    # Starting state (for reproduction)
+    starting_deck_p1 = Column(JSONB, nullable=False)  # List of card names
+    starting_deck_p2 = Column(JSONB, nullable=False)  # List of card names
+    first_player_id = Column(String(255), nullable=False)
+    
+    # Game progression
+    play_by_play = Column(JSONB, nullable=False)  # List of action entries
+    turn_count = Column(Integer, nullable=False)
+    
+    # Timestamps
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        index=True  # Index for cleanup queries
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    
+    def __repr__(self):
+        return f"<GamePlayback(id={self.id}, game_id={self.game_id}, turns={self.turn_count})>"
+
+
+class PlayerStatsModel(Base):
+    """
+    Database model for player statistics.
+    
+    Aggregated player statistics for leaderboards and analytics.
+    Retention: Permanent.
+    """
+    __tablename__ = "player_stats"
+    
+    # Primary key - links to users table for authenticated users
+    # For AI players, uses their generated ID (e.g., "ai-player-123")
+    player_id = Column(String(255), primary_key=True)
+    
+    # Display name (cached for leaderboard display)
+    display_name = Column(String(255), nullable=False)
+    
+    # Overall stats
+    games_played = Column(Integer, nullable=False, default=0)
+    games_won = Column(Integer, nullable=False, default=0)
+    
+    # Tussle stats
+    total_tussles = Column(Integer, nullable=False, default=0)
+    tussles_won = Column(Integer, nullable=False, default=0)
+    
+    # Card-specific stats (JSONB for flexibility)
+    # Structure: {
+    #   "Ka": {"games_played": 50, "games_won": 28, "tussles_initiated": 30, "tussles_won": 22},
+    #   "Knight": {"games_played": 45, "games_won": 25, ...}
+    # }
+    card_stats = Column(JSONB, nullable=False, default={})
+    
+    # Timestamps
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now()
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now()
+    )
+    
+    # Indexes for leaderboards
+    __table_args__ = (
+        Index('idx_player_stats_games_won', 'games_won'),
+        Index('idx_player_stats_games_played', 'games_played'),
+    )
+    
+    def __repr__(self):
+        return f"<PlayerStats(player_id={self.player_id}, wins={self.games_won}/{self.games_played})>"
+    
+    @property
+    def win_rate(self) -> float:
+        """Calculate win rate as percentage."""
+        if self.games_played == 0:
+            return 0.0
+        return (self.games_won / self.games_played) * 100

--- a/backend/src/api/stats_service.py
+++ b/backend/src/api/stats_service.py
@@ -1,0 +1,458 @@
+"""
+Stats service for logging and analytics.
+
+Handles AI decision logging, game playback recording, and player stats updates.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional, TYPE_CHECKING
+
+# Lazy imports for database components (avoid requiring DATABASE_URL when not using DB)
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+    from api.db_models import (
+        AIDecisionLogModel,
+        GamePlaybackModel,
+        PlayerStatsModel,
+        GameModel,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def _get_session_local():
+    """Lazy import of SessionLocal to avoid requiring DATABASE_URL at import time."""
+    from api.database import SessionLocal
+    return SessionLocal
+
+
+def _get_models():
+    """Lazy import of database models."""
+    from api.db_models import (
+        AIDecisionLogModel,
+        GamePlaybackModel,
+        PlayerStatsModel,
+        GameModel,
+    )
+    return AIDecisionLogModel, GamePlaybackModel, PlayerStatsModel, GameModel
+
+
+class StatsService:
+    """
+    Service for managing game statistics and logging.
+    
+    Provides methods for:
+    - Logging AI decisions (prompts/responses)
+    - Recording game playback data
+    - Updating player statistics
+    - Cleaning up old records
+    """
+    
+    def __init__(self, use_database: bool = True):
+        """
+        Initialize the stats service.
+        
+        Args:
+            use_database: Whether to persist to database (False for testing)
+        """
+        self.use_database = use_database
+    
+    # ========================================
+    # AI Decision Logging
+    # ========================================
+    
+    def log_ai_decision(
+        self,
+        game_id: str,
+        turn_number: int,
+        player_id: str,
+        model_name: str,
+        prompts_version: str,
+        prompt: str,
+        response: str,
+        action_number: Optional[int] = None,
+        reasoning: Optional[str] = None,
+    ) -> None:
+        """
+        Log an AI decision for debugging and analysis.
+        
+        Args:
+            game_id: Game ID (UUID string)
+            turn_number: Current turn number
+            player_id: AI player ID in the game
+            model_name: Gemini model name (e.g., "gemini-2.0-flash")
+            prompts_version: Version of prompts.py (e.g., "1.0")
+            prompt: Full prompt sent to the AI
+            response: Raw response from the AI
+            action_number: Parsed action number (if successful)
+            reasoning: AI's reasoning (if parsed)
+        """
+        if not self.use_database:
+            logger.debug(f"AI decision logged (no-db): game={game_id}, turn={turn_number}")
+            return
+        
+        SessionLocal = _get_session_local()
+        AIDecisionLogModel, _, _, _ = _get_models()
+        
+        db = SessionLocal()
+        try:
+            log_entry = AIDecisionLogModel(
+                game_id=uuid.UUID(game_id),
+                turn_number=turn_number,
+                player_id=player_id,
+                model_name=model_name,
+                prompts_version=prompts_version,
+                prompt=prompt,
+                response=response,
+                action_number=action_number,
+                reasoning=reasoning,
+            )
+            db.add(log_entry)
+            db.commit()
+            logger.debug(f"AI decision logged: game={game_id}, turn={turn_number}, model={model_name}")
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Failed to log AI decision: {e}")
+            # Don't raise - logging is non-critical
+        finally:
+            db.close()
+    
+    # ========================================
+    # Game Playback Recording
+    # ========================================
+    
+    def record_game_playback(
+        self,
+        game_id: str,
+        player1_id: str,
+        player1_name: str,
+        player2_id: str,
+        player2_name: str,
+        winner_id: Optional[str],
+        starting_deck_p1: list[str],
+        starting_deck_p2: list[str],
+        first_player_id: str,
+        play_by_play: list[dict],
+        turn_count: int,
+    ) -> None:
+        """
+        Record a completed game for playback and analysis.
+        
+        Args:
+            game_id: Game ID (UUID string)
+            player1_id: Player 1 ID
+            player1_name: Player 1 display name
+            player2_id: Player 2 ID
+            player2_name: Player 2 display name
+            winner_id: Winner's player ID (None if tie/abandoned)
+            starting_deck_p1: List of card names for player 1
+            starting_deck_p2: List of card names for player 2
+            first_player_id: ID of player who went first
+            play_by_play: List of play-by-play entries
+            turn_count: Total number of turns
+        """
+        if not self.use_database:
+            logger.debug(f"Game playback recorded (no-db): game={game_id}")
+            return
+        
+        SessionLocal = _get_session_local()
+        _, GamePlaybackModel, _, _ = _get_models()
+        
+        db = SessionLocal()
+        try:
+            # Check if playback already exists (idempotent)
+            existing = db.query(GamePlaybackModel).filter(
+                GamePlaybackModel.game_id == uuid.UUID(game_id)
+            ).first()
+            
+            if existing:
+                logger.debug(f"Playback already exists for game {game_id}")
+                return
+            
+            playback = GamePlaybackModel(
+                game_id=uuid.UUID(game_id),
+                player1_id=player1_id,
+                player1_name=player1_name,
+                player2_id=player2_id,
+                player2_name=player2_name,
+                winner_id=winner_id,
+                starting_deck_p1=starting_deck_p1,
+                starting_deck_p2=starting_deck_p2,
+                first_player_id=first_player_id,
+                play_by_play=play_by_play,
+                turn_count=turn_count,
+                completed_at=datetime.now(timezone.utc),
+            )
+            db.add(playback)
+            db.commit()
+            logger.info(f"Game playback recorded: game={game_id}, turns={turn_count}")
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Failed to record game playback: {e}")
+            # Don't raise - logging is non-critical
+        finally:
+            db.close()
+    
+    # ========================================
+    # Player Stats Updates
+    # ========================================
+    
+    def update_player_stats(
+        self,
+        player_id: str,
+        display_name: str,
+        won: bool,
+        cards_used: list[str],
+        tussles_initiated: int = 0,
+        tussles_won: int = 0,
+    ) -> None:
+        """
+        Update a player's statistics after a game.
+        
+        Args:
+            player_id: Player ID (Google ID or AI ID)
+            display_name: Player's display name
+            won: Whether the player won
+            cards_used: List of card names used in the game
+            tussles_initiated: Number of tussles the player initiated
+            tussles_won: Number of tussles the player won
+        """
+        if not self.use_database:
+            logger.debug(f"Player stats updated (no-db): player={player_id}")
+            return
+        
+        SessionLocal = _get_session_local()
+        _, _, PlayerStatsModel, _ = _get_models()
+        
+        db = SessionLocal()
+        try:
+            # Get or create player stats
+            stats = db.query(PlayerStatsModel).filter(
+                PlayerStatsModel.player_id == player_id
+            ).first()
+            
+            if not stats:
+                stats = PlayerStatsModel(
+                    player_id=player_id,
+                    display_name=display_name,
+                    games_played=0,
+                    games_won=0,
+                    total_tussles=0,
+                    tussles_won=0,
+                    card_stats={},
+                )
+                db.add(stats)
+            
+            # Update overall stats
+            stats.games_played += 1
+            if won:
+                stats.games_won += 1
+            stats.total_tussles += tussles_initiated
+            stats.tussles_won += tussles_won
+            stats.display_name = display_name  # Update display name in case it changed
+            
+            # Update card-specific stats
+            card_stats = dict(stats.card_stats or {})
+            for card_name in set(cards_used):  # Use set to count each card once per game
+                if card_name not in card_stats:
+                    card_stats[card_name] = {
+                        "games_played": 0,
+                        "games_won": 0,
+                    }
+                card_stats[card_name]["games_played"] += 1
+                if won:
+                    card_stats[card_name]["games_won"] += 1
+            
+            stats.card_stats = card_stats
+            
+            db.commit()
+            logger.info(f"Player stats updated: player={player_id}, total_games={stats.games_played}")
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Failed to update player stats: {e}")
+            # Don't raise - stats are non-critical
+        finally:
+            db.close()
+    
+    # ========================================
+    # Data Retention Cleanup
+    # ========================================
+    
+    def cleanup_old_ai_logs(self, max_age_hours: int = 1) -> int:
+        """
+        Delete AI decision logs older than the specified age.
+        
+        Args:
+            max_age_hours: Maximum age in hours (default: 1)
+            
+        Returns:
+            Number of records deleted
+        """
+        if not self.use_database:
+            return 0
+        
+        SessionLocal = _get_session_local()
+        AIDecisionLogModel, _, _, _ = _get_models()
+        
+        db = SessionLocal()
+        try:
+            cutoff = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
+            deleted = db.query(AIDecisionLogModel).filter(
+                AIDecisionLogModel.created_at < cutoff
+            ).delete()
+            db.commit()
+            logger.info(f"Cleaned up {deleted} AI decision logs older than {max_age_hours} hour(s)")
+            return deleted
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Failed to cleanup AI logs: {e}")
+            return 0
+        finally:
+            db.close()
+    
+    def cleanup_old_playback(self, max_age_hours: int = 24) -> int:
+        """
+        Delete game playback records older than the specified age.
+        
+        Args:
+            max_age_hours: Maximum age in hours (default: 24)
+            
+        Returns:
+            Number of records deleted
+        """
+        if not self.use_database:
+            return 0
+        
+        SessionLocal = _get_session_local()
+        _, GamePlaybackModel, _, _ = _get_models()
+        
+        db = SessionLocal()
+        try:
+            cutoff = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
+            deleted = db.query(GamePlaybackModel).filter(
+                GamePlaybackModel.created_at < cutoff
+            ).delete()
+            db.commit()
+            logger.info(f"Cleaned up {deleted} game playback records older than {max_age_hours} hour(s)")
+            return deleted
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Failed to cleanup playback records: {e}")
+            return 0
+        finally:
+            db.close()
+    
+    # ========================================
+    # Query Methods (for future stats API)
+    # ========================================
+    
+    def get_player_stats(self, player_id: str) -> Optional[dict]:
+        """
+        Get statistics for a specific player.
+        
+        Args:
+            player_id: Player ID
+            
+        Returns:
+            Dict with player stats or None if not found
+        """
+        if not self.use_database:
+            return None
+        
+        SessionLocal = _get_session_local()
+        _, _, PlayerStatsModel, _ = _get_models()
+        
+        db = SessionLocal()
+        try:
+            stats = db.query(PlayerStatsModel).filter(
+                PlayerStatsModel.player_id == player_id
+            ).first()
+            
+            if not stats:
+                return None
+            
+            return {
+                "player_id": stats.player_id,
+                "display_name": stats.display_name,
+                "games_played": stats.games_played,
+                "games_won": stats.games_won,
+                "win_rate": stats.win_rate,
+                "total_tussles": stats.total_tussles,
+                "tussles_won": stats.tussles_won,
+                "card_stats": stats.card_stats,
+            }
+        except Exception as e:
+            logger.error(f"Failed to get player stats: {e}")
+            return None
+        finally:
+            db.close()
+    
+    def get_leaderboard(self, limit: int = 10) -> list[dict]:
+        """
+        Get top players by win rate (minimum 5 games).
+        
+        Args:
+            limit: Maximum number of players to return
+            
+        Returns:
+            List of player stats dicts ordered by win rate
+        """
+        if not self.use_database:
+            return []
+        
+        SessionLocal = _get_session_local()
+        _, _, PlayerStatsModel, _ = _get_models()
+        
+        db = SessionLocal()
+        try:
+            # Get players with at least 5 games, ordered by win rate
+            stats_list = db.query(PlayerStatsModel).filter(
+                PlayerStatsModel.games_played >= 5
+            ).order_by(
+                (PlayerStatsModel.games_won.cast(db.bind.dialect.type_descriptor(
+                    type(PlayerStatsModel.games_won.type)
+                )) / PlayerStatsModel.games_played).desc()
+            ).limit(limit).all()
+            
+            # Fallback to simple ordering if the above doesn't work
+            if not stats_list:
+                stats_list = db.query(PlayerStatsModel).filter(
+                    PlayerStatsModel.games_played >= 5
+                ).order_by(
+                    PlayerStatsModel.games_won.desc()
+                ).limit(limit).all()
+            
+            return [
+                {
+                    "player_id": s.player_id,
+                    "display_name": s.display_name,
+                    "games_played": s.games_played,
+                    "games_won": s.games_won,
+                    "win_rate": s.win_rate,
+                }
+                for s in stats_list
+            ]
+        except Exception as e:
+            logger.error(f"Failed to get leaderboard: {e}")
+            return []
+        finally:
+            db.close()
+
+
+# Global singleton instance
+_stats_service: Optional[StatsService] = None
+
+
+def get_stats_service() -> StatsService:
+    """
+    Get the global StatsService instance.
+    
+    Returns:
+        StatsService instance
+    """
+    global _stats_service
+    if _stats_service is None:
+        _stats_service = StatsService()
+    return _stats_service

--- a/backend/src/game_engine/ai/prompts.py
+++ b/backend/src/game_engine/ai/prompts.py
@@ -4,6 +4,11 @@ Prompt templates for the AI player.
 These prompts guide Claude to play GGLTCG strategically and aggressively.
 """
 
+# Version tracking for AI decision logs
+# Increment this when making significant changes to prompts or strategy
+# Format: MAJOR.MINOR (MAJOR = strategy overhaul, MINOR = tweaks/fixes)
+PROMPTS_VERSION = "1.0"
+
 # Card effect library for AI strategic understanding
 CARD_EFFECTS_LIBRARY = {
     # TOY CARDS

--- a/backend/tests/test_stats_service.py
+++ b/backend/tests/test_stats_service.py
@@ -1,0 +1,245 @@
+"""
+Tests for the StatsService (AI decision logging, game playback, player stats).
+
+These tests verify the data logging and statistics functionality.
+"""
+
+import pytest
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+# Add backend/src to path
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+class TestStatsServiceNoDb:
+    """Tests for StatsService without database (unit tests)."""
+    
+    def test_log_ai_decision_no_db(self):
+        """Test that logging works without database."""
+        from api.stats_service import StatsService
+        
+        service = StatsService(use_database=False)
+        
+        # Should not raise even without database
+        service.log_ai_decision(
+            game_id=str(uuid.uuid4()),
+            turn_number=1,
+            player_id="ai-player-1",
+            model_name="gemini-2.0-flash",
+            prompts_version="1.0",
+            prompt="Test prompt",
+            response='{"action_number": 1, "reasoning": "Test"}',
+            action_number=1,
+            reasoning="Test",
+        )
+    
+    def test_record_game_playback_no_db(self):
+        """Test that playback recording works without database."""
+        from api.stats_service import StatsService
+        
+        service = StatsService(use_database=False)
+        
+        # Should not raise even without database
+        service.record_game_playback(
+            game_id=str(uuid.uuid4()),
+            player1_id="player1",
+            player1_name="Alice",
+            player2_id="player2",
+            player2_name="Bob",
+            winner_id="player1",
+            starting_deck_p1=["Ka", "Knight", "Clean", "Rush", "Wizard", "Demideca"],
+            starting_deck_p2=["Ka", "Knight", "Clean", "Rush", "Wizard", "Demideca"],
+            first_player_id="player1",
+            play_by_play=[
+                {"turn": 1, "player": "Alice", "description": "Played Ka"},
+            ],
+            turn_count=5,
+        )
+    
+    def test_update_player_stats_no_db(self):
+        """Test that player stats update works without database."""
+        from api.stats_service import StatsService
+        
+        service = StatsService(use_database=False)
+        
+        # Should not raise even without database
+        service.update_player_stats(
+            player_id="player1",
+            display_name="Alice",
+            won=True,
+            cards_used=["Ka", "Knight", "Clean"],
+            tussles_initiated=3,
+            tussles_won=2,
+        )
+    
+    def test_cleanup_no_db_returns_zero(self):
+        """Test that cleanup returns 0 without database."""
+        from api.stats_service import StatsService
+        
+        service = StatsService(use_database=False)
+        
+        assert service.cleanup_old_ai_logs() == 0
+        assert service.cleanup_old_playback() == 0
+    
+    def test_get_player_stats_no_db_returns_none(self):
+        """Test that get_player_stats returns None without database."""
+        from api.stats_service import StatsService
+        
+        service = StatsService(use_database=False)
+        
+        assert service.get_player_stats("player1") is None
+    
+    def test_get_leaderboard_no_db_returns_empty(self):
+        """Test that leaderboard returns empty list without database."""
+        from api.stats_service import StatsService
+        
+        service = StatsService(use_database=False)
+        
+        assert service.get_leaderboard() == []
+
+
+class TestPromptsVersion:
+    """Tests for prompts version tracking."""
+    
+    def test_prompts_version_exists(self):
+        """Test that PROMPTS_VERSION is defined."""
+        from game_engine.ai.prompts import PROMPTS_VERSION
+        
+        assert PROMPTS_VERSION is not None
+        assert isinstance(PROMPTS_VERSION, str)
+        assert len(PROMPTS_VERSION) > 0
+    
+    def test_prompts_version_format(self):
+        """Test that PROMPTS_VERSION follows expected format (MAJOR.MINOR)."""
+        from game_engine.ai.prompts import PROMPTS_VERSION
+        
+        parts = PROMPTS_VERSION.split(".")
+        assert len(parts) >= 1, "Version should have at least one part"
+        # Should be numeric
+        for part in parts:
+            assert part.isdigit(), f"Version part '{part}' should be numeric"
+
+
+class TestLLMPlayerDecisionInfo:
+    """Tests for LLMPlayer decision info tracking."""
+    
+    def test_get_last_decision_info_initial(self):
+        """Test that get_last_decision_info returns empty info initially."""
+        # Mock the API key to avoid requiring real credentials
+        with patch.dict('os.environ', {'GOOGLE_API_KEY': 'test-key'}):
+            with patch('google.generativeai.configure'):
+                with patch('google.generativeai.GenerativeModel'):
+                    from game_engine.ai.llm_player import LLMPlayer
+                    
+                    player = LLMPlayer(provider="gemini")
+                    info = player.get_last_decision_info()
+                    
+                    assert info["prompt"] is None
+                    assert info["response"] is None
+                    assert info["model_name"] is not None
+                    assert info["prompts_version"] is not None
+
+
+class TestDbModels:
+    """Tests for database models."""
+    
+    def test_ai_decision_log_model_exists(self):
+        """Test that AIDecisionLogModel is properly defined."""
+        from api.db_models import AIDecisionLogModel
+        
+        assert AIDecisionLogModel.__tablename__ == "ai_decision_logs"
+    
+    def test_game_playback_model_exists(self):
+        """Test that GamePlaybackModel is properly defined."""
+        from api.db_models import GamePlaybackModel
+        
+        assert GamePlaybackModel.__tablename__ == "game_playback"
+    
+    def test_player_stats_model_exists(self):
+        """Test that PlayerStatsModel is properly defined."""
+        from api.db_models import PlayerStatsModel
+        
+        assert PlayerStatsModel.__tablename__ == "player_stats"
+    
+    def test_player_stats_win_rate_calculation(self):
+        """Test win rate calculation on PlayerStatsModel."""
+        from api.db_models import PlayerStatsModel
+        
+        # Create instance without database
+        stats = PlayerStatsModel(
+            player_id="test-player",
+            display_name="Test",
+            games_played=10,
+            games_won=7,
+            total_tussles=0,
+            tussles_won=0,
+            card_stats={},
+        )
+        
+        assert stats.win_rate == 70.0
+    
+    def test_player_stats_win_rate_zero_games(self):
+        """Test win rate is 0 when no games played."""
+        from api.db_models import PlayerStatsModel
+        
+        stats = PlayerStatsModel(
+            player_id="test-player",
+            display_name="Test",
+            games_played=0,
+            games_won=0,
+            total_tussles=0,
+            tussles_won=0,
+            card_stats={},
+        )
+        
+        assert stats.win_rate == 0.0
+
+
+class TestMigration:
+    """Tests for the Alembic migration."""
+    
+    def test_migration_file_exists(self):
+        """Test that migration file exists."""
+        migration_path = Path(__file__).parent.parent / "alembic" / "versions" / "004_create_stats_tables.py"
+        assert migration_path.exists(), f"Migration file not found at {migration_path}"
+    
+    def test_migration_imports(self):
+        """Test that migration can be imported."""
+        # Import the migration module
+        import importlib.util
+        migration_path = Path(__file__).parent.parent / "alembic" / "versions" / "004_create_stats_tables.py"
+        
+        spec = importlib.util.spec_from_file_location("migration_004", str(migration_path))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        
+        # Check revision info
+        assert module.revision == "004"
+        assert module.down_revision == "003"
+        
+        # Check upgrade and downgrade functions exist
+        assert hasattr(module, "upgrade")
+        assert hasattr(module, "downgrade")
+        assert callable(module.upgrade)
+        assert callable(module.downgrade)
+
+
+class TestStatsServiceSingleton:
+    """Tests for stats service singleton."""
+    
+    def test_get_stats_service_returns_same_instance(self):
+        """Test that get_stats_service returns singleton."""
+        from api.stats_service import get_stats_service, _stats_service
+        
+        # Reset singleton for test
+        import api.stats_service
+        api.stats_service._stats_service = None
+        
+        service1 = get_stats_service()
+        service2 = get_stats_service()
+        
+        assert service1 is service2


### PR DESCRIPTION
## Summary
Phase 2 database enhancements per DATABASE_SCHEMA.md and issue #81.

## New Features

### 📝 AI Decision Logging (1 hour retention)
- Stores Gemini prompts and responses for debugging AI behavior
- Tracks model name (e.g., `gemini-2.0-flash`) and prompts version (`1.0`)
- Includes parsed action number and reasoning
- Enables correlation between prompt changes and AI behavior

### 🎮 Game Playback (24 hour retention)  
- Records completed games with starting decks for both players
- Stores full play-by-play for analysis/replay
- Tracks winner, turn count, and first player

### 📊 Player Stats (permanent)
- Tracks games played/won for both human and AI players
- Records tussle statistics (initiated/won)
- Per-card usage statistics (which cards appear in winning decks)
- Supports future leaderboard functionality

## Verified Locally
Played 2 test games and confirmed:
- ✅ 19 AI decision logs recorded
- ✅ 2 game playback records saved
- ✅ Player stats for both human and AI updated

## Files Added
- `backend/src/api/stats_service.py` - Service for all stats operations
- `backend/alembic/versions/004_create_stats_tables.py` - Migration for 3 new tables
- `backend/tests/test_stats_service.py` - 17 unit tests

## Files Modified
- `backend/src/api/db_models.py` - Added 3 new SQLAlchemy models
- `backend/src/api/game_service.py` - Save playback and player stats on game completion
- `backend/src/api/routes_actions.py` - Log AI decisions after successful actions
- `backend/src/game_engine/ai/llm_player.py` - Track last prompt/response for logging
- `backend/src/game_engine/ai/prompts.py` - Added PROMPTS_VERSION constant

## Technical Notes
- Uses lazy imports in `stats_service.py` to avoid DATABASE_URL requirement during tests
- All logging is non-critical (failures don't break gameplay)
- Migration will auto-run on Render deployment

## Next Steps (Future PRs)
- Phase 2: Add retention cleanup via cron jobs or scheduled task
- Phase 3: Add stats API endpoints and frontend leaderboard

Closes #81