### PR TITLE
Add Paper Plane and Monster cards (Issue #204) (#239)

### DIFF
--- a/backend/data/cards.csv
+++ b/backend/data/cards.csv
@@ -28,3 +28,4 @@ Hind Leg Kicker,18,1,"When you play a card (not this one), gain 1 charge.",3,3,1
 Gibbers,18,1,Your opponent's cards cost 1 more.,1,1,1,,,#eb9113,#eb9113,opponent_cost_increase:1
 That was fun,18,0,Unsleep an action card.,,,,,,#8B5FA8,#8B5FA8,unsleep:actions:1
 Paper Plane,18,1,This card can direct attack even if your opponent has cards in play.,2,2,1,,,#87CEEB,#4682B4,direct_attack
+Monster,18,2,"When played, set all cards' stamina to 1, if they naturally have 1 stamina, they are sleeped instead.",3,1,2,,,#4A0E4E,#8B008B,damage_all_opponent_cards:1

--- a/backend/data/cards_beta_20251206.csv
+++ b/backend/data/cards_beta_20251206.csv
@@ -25,3 +25,6 @@ Belchaletta,Beta,1,"At the start of your turn, gain 2 charge.",3,3,4,,,#eb9113,#
 Hind Leg Kicker,Beta,1,"When you play a card (not this one), gain 1 charge.",3,3,1,,,#eb9113,#eb9113,on_card_played_gain_cc:1
 Drum,Beta,1,Your cards have 2 more speed.,1,3,2,,,#eb9113,#eb9113,stat_boost:speed:2
 Violin,Beta,1,Your cards have 2 more strength.,3,1,2,,,#eb9113,#eb9113,stat_boost:strength:2
+Gibbers,Beta,1,Your opponent's cards cost 1 more.,1,1,1,,,#eb9113,#eb9113,opponent_cost_increase:1
+Paper Plane,Beta,1,This card can direct attack even if your opponent has cards in play.,2,2,1,,,#87CEEB,#4682B4,direct_attack
+Monster,Beta,2,"When played, set all opponent's cards' stamina to 1.",3,1,2,,,#4A0E4E,#8B008B,damage_all_opponent_cards:1

--- a/backend/src/game_engine/ai/prompts/card_library.py
+++ b/backend/src/game_engine/ai/prompts/card_library.py
@@ -186,4 +186,10 @@ CARD_EFFECTS_LIBRARY = {
         "strategic_use": "HAND PRESSURE - Bypasses opponent's defensive board to directly attack their hand. Use to pressure opponents who turtle behind defenders. Still costs CC and counts toward 2 direct attack limit per turn.",
         "threat_level": "MEDIUM - Can attack your hand directly even when you have defenders. Consider removing before it chips away your hand."
     },
+    "Monster": {
+        "type": "Toy",
+        "effect": "On play: Set all cards' stamina to 1. If they naturally have 1 stamina, they are sleeped instead.",
+        "strategic_use": "BOARD EQUALIZER - Affects ALL cards in play (yours and opponent's). Cards with base 1 stamina (Ka, Hind Leg Kicker, Paper Plane, Gibbers) get sleeped. Use when opponent has more high-stamina cards than you.",
+        "threat_level": "MEDIUM - Affects YOUR cards too. Dangerous if you have more high-stamina cards in play."
+    },
 }

--- a/backend/src/game_engine/effects_constants.py
+++ b/backend/src/game_engine/effects_constants.py
@@ -72,6 +72,9 @@ class EffectDefinitions:
     # === Ability Effects ===
     REMOVE_STAMINA_ABILITY_1 = "remove_stamina_ability:1"
     
+    # === Damage Effects ===
+    DAMAGE_ALL_OPPONENT_CARDS_1 = "damage_all_opponent_cards:1"
+    
     # === Compound Effects (multiple effects separated by ;) ===
     ARCHER_EFFECTS = "cannot_tussle;remove_stamina_ability:1"
     
@@ -159,6 +162,7 @@ CARD_EFFECT_DEFINITIONS: Dict[str, str] = {
     "Gibbers": EffectDefinitions.OPPONENT_COST_INCREASE_1,
     "That was fun": EffectDefinitions.UNSLEEP_ACTIONS_1,
     "Paper Plane": EffectDefinitions.DIRECT_ATTACK,
+    "Monster": EffectDefinitions.DAMAGE_ALL_OPPONENT_CARDS_1,
 }
 
 

--- a/backend/src/game_engine/rules/effects/effect_registry.py
+++ b/backend/src/game_engine/rules/effects/effect_registry.py
@@ -126,6 +126,9 @@ class EffectFactory:
             elif effect_type == "opponent_cost_increase":
                 effect = cls._parse_opponent_cost_increase(parts, source_card)
                 effects.append(effect)
+            elif effect_type == "damage_all_opponent_cards":
+                effect = cls._parse_damage_all_opponent_cards(parts, source_card)
+                effects.append(effect)
             else:
                 raise ValueError(f"Unknown effect type: {effect_type}")
         
@@ -778,6 +781,49 @@ class EffectFactory:
         # Note: ArcherActivatedAbility currently only uses cc_cost in __init__
         # The amount parameter would need to be added if we want variable damage
         return ArcherActivatedAbility(source_card)
+
+    @classmethod
+    def _parse_damage_all_opponent_cards(cls, parts: List[str], source_card: "Card") -> BaseEffect:
+        """
+        Parse a damage_all_opponent_cards effect definition.
+        
+        Format: "damage_all_opponent_cards:amount"
+        - amount: Damage to deal to each opponent card (typically 1)
+        
+        One-time effect when played: deals damage to all opponent's cards in play.
+        Cards that reach 0 stamina are sleeped.
+        
+        Args:
+            parts: Split effect definition parts
+            source_card: The card providing this effect
+            
+        Returns:
+            DamageAllOpponentCardsEffect instance
+            
+        Raises:
+            ValueError: If format is invalid
+        """
+        if len(parts) != 2:
+            raise ValueError(
+                f"damage_all_opponent_cards effect requires exactly 1 parameter: amount. "
+                f"Got {len(parts) - 1} parameters: {':'.join(parts)}"
+            )
+        
+        try:
+            damage = int(parts[1].strip())
+        except ValueError:
+            raise ValueError(
+                f"Invalid damage '{parts[1]}' for damage_all_opponent_cards. Must be an integer."
+            )
+        
+        if damage < 1:
+            raise ValueError(
+                f"Invalid damage {damage} for damage_all_opponent_cards. Must be at least 1."
+            )
+        
+        # Import here to avoid circular dependency
+        from .action_effects import DamageAllOpponentCardsEffect
+        return DamageAllOpponentCardsEffect(source_card, damage)
 
     @classmethod
     def _parse_sleep_target(cls, parts: List[str], source_card: "Card") -> BaseEffect:


### PR DESCRIPTION
* feat: Add Paper Plane card with direct attack ability

Paper Plane is a Toy card (Cost: 1, Speed: 3, Strength: 2, Stamina: 2) that can direct attack opponent's hand even when opponent has cards in play.

Implementation:
- Add DirectAttackEffect continuous effect class
- Add 'direct_attack' effect parser in EffectRegistry
- Update ActionValidator to offer direct attack when card has effect
- Update GameEngine.can_tussle to bypass 'opponent has cards in play' check
- Add Paper Plane to cards.csv with new direct_attack effect
- Add AI strategic guidance for Paper Plane
- Add comprehensive test suite (14 tests)

The effect still respects the normal 2 direct attacks per turn limit and cannot be used when opponent has no cards in hand.

* feat: Add Paper Plane card with direct attack + UX improvements

Paper Plane Implementation:
- New Toy card (Cost: 1, Speed: 2, Strength: 2, Stamina: 1)
- DirectAttackEffect allows tussling opponent's hand even with cards in play
- Added to cards.csv, effect registry, AI prompts
- 14 comprehensive tests

UX Improvements:
- Tussle target modal now shows 'Direct Attack' option when available
- Direct Attack button uses same gold glow as selected cards
- Ballaber button enabled when alternative cost available (sleep a card)
- Pay CC option disabled when unaffordable (with lock icon)
- Wake/Sun no longer shown when no sleeping cards to target

Files changed:
- backend: action_validator.py, continuous_effects.py, effect_registry.py, effects_constants.py, game_engine.py, cards.csv, card_library.py
- frontend: TargetSelectionModal.tsx, ActionPanel.tsx, GameBoard.tsx
- tests: test_paper_plane.py

* Add Paper Plane and Monster cards

Paper Plane:
- Cost 1, Stats: 2/2/1
- Effect: Can direct attack even if opponent has cards in play
- Implemented direct_attack effect

Monster:
- Cost 2, Stats: 3/1/2
- Effect: When played, set all cards' stamina to 1, if they naturally have 1 stamina, they are sleeped instead
- Implemented damage_all_opponent_cards effect
- Respects protection effects (Beary, Sock Sorcerer)

Also includes:
- Updated card library for AI
- Added comprehensive tests for both cards
- Fixed Monster test assertions to match actual card behavior

* Fix Monster card: affect ALL cards, check base stamina for sleep

- Implementation now affects both players' cards per card text
- Sleep condition checks base stamina (natural), not current stamina
- Updated card_library.py description to match card text exactly
- Updated tests to verify correct behavior
- Added test for damaged cards with higher base stamina

---------

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
